### PR TITLE
Replace deprecated functions

### DIFF
--- a/echo_test.go
+++ b/echo_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -64,7 +64,7 @@ func TestEchoServerMiddleware(t *testing.T) {
 	e := echo.New()
 	e.Use(client.EchoMiddleware)
 	e.POST("/:slug/test", func(c echo.Context) (err error) {
-		body, err := ioutil.ReadAll(c.Request().Body)
+		body, err := io.ReadAll(c.Request().Body)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, body)
 		reqData, _ := json.Marshal(exampleData2)

--- a/errors.go
+++ b/errors.go
@@ -12,8 +12,10 @@ import (
 
 type ctxKey string
 
-var ErrorListCtxKey = ctxKey("error-list")
-var CurrentRequestMessageID = ctxKey("current-req-msg-id")
+var (
+	ErrorListCtxKey         = ctxKey("error-list")
+	CurrentRequestMessageID = ctxKey("current-req-msg-id")
+)
 
 // ATError is the Apitoolkit error type/object
 type ATError struct {

--- a/errors_test.go
+++ b/errors_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -84,7 +84,6 @@ func TestErrorReporting(t *testing.T) {
 	assert.True(t, publishCalled)
 }
 
-
 func TestGinMiddlewareGETError(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	client := &Client{
@@ -101,7 +100,7 @@ func TestGinMiddlewareGETError(t *testing.T) {
 	router.Use(client.GinMiddleware)
 
 	router.GET("/:slug/test", func(c *gin.Context) {
-		body, err := ioutil.ReadAll(c.Request.Body)
+		body, err := io.ReadAll(c.Request.Body)
 		assert.NoError(t, err)
 		assert.Equal(t, []byte{}, body)
 

--- a/gin.go
+++ b/gin.go
@@ -42,15 +42,15 @@ func (c *Client) GinMiddleware(ctx *gin.Context) {
 	ctx.Writer = blw
 
 	ctx.Next()
-	
+
 	pathParams := map[string]string{}
 	for _, param := range ctx.Params {
 		pathParams[param.Key] = param.Value
 	}
 
-	payload := c.buildPayload(GoGinSDKType, start, 
+	payload := c.buildPayload(GoGinSDKType, start,
 		ctx.Request, ctx.Writer.Status(),
-		reqByteBody, blw.body.Bytes(), ctx.Writer.Header().Clone(), 
+		reqByteBody, blw.body.Bytes(), ctx.Writer.Header().Clone(),
 		pathParams, ctx.FullPath(),
 		c.config.RedactHeaders, c.config.RedactRequestBody, c.config.RedactResponseBody,
 		errorList,

--- a/gin.go
+++ b/gin.go
@@ -3,7 +3,7 @@ package apitoolkit
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -35,8 +35,8 @@ func (c *Client) GinMiddleware(ctx *gin.Context) {
 	ctx.Request = ctx.Request.WithContext(newCtx)
 
 	start := time.Now()
-	reqByteBody, _ := ioutil.ReadAll(ctx.Request.Body)
-	ctx.Request.Body = ioutil.NopCloser(bytes.NewBuffer(reqByteBody))
+	reqByteBody, _ := io.ReadAll(ctx.Request.Body)
+	ctx.Request.Body = io.NopCloser(bytes.NewBuffer(reqByteBody))
 
 	blw := &ginBodyLogWriter{body: bytes.NewBuffer([]byte{}), ResponseWriter: ctx.Writer}
 	ctx.Writer = blw

--- a/gin_test.go
+++ b/gin_test.go
@@ -3,7 +3,7 @@ package apitoolkit
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -64,7 +64,7 @@ func TestGinMiddleware(t *testing.T) {
 	router := gin.New()
 	router.Use(client.GinMiddleware)
 	router.POST("/:slug/test", func(c *gin.Context) {
-		body, err := ioutil.ReadAll(c.Request.Body)
+		body, err := io.ReadAll(c.Request.Body)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, body)
 		reqData, _ := json.Marshal(exampleData2)
@@ -129,7 +129,7 @@ func TestGinMiddlewareGET(t *testing.T) {
 	router.Use(client.GinMiddleware)
 
 	router.GET("/:slug/test", func(c *gin.Context) {
-		body, err := ioutil.ReadAll(c.Request.Body)
+		body, err := io.ReadAll(c.Request.Body)
 		assert.NoError(t, err)
 		assert.Equal(t, []byte{}, body)
 

--- a/gin_test.go
+++ b/gin_test.go
@@ -20,7 +20,7 @@ func TestGinMiddleware(t *testing.T) {
 	client := &Client{
 		config: &Config{
 			RedactHeaders:      []string{"X-Api-Key", "Accept-Encoding"},
-			RedactResponseBody: exampleDataRedaction, 
+			RedactResponseBody: exampleDataRedaction,
 		},
 	}
 	var publishCalled bool

--- a/integration_test.go
+++ b/integration_test.go
@@ -17,12 +17,12 @@ import (
 func TestReporting(t *testing.T) {
 	ctx := context.Background()
 	cfg := Config{
-			APIKey: os.Getenv("APITOOLKIT_KEY"),
-			RootURL: "http://localhost:8080",
-			RedactHeaders:      []string{"X-Api-Key", "Accept-Encoding"},
-			RedactResponseBody: exampleDataRedaction,
-			Tags: []string{"staging"},
-		}
+		APIKey:             os.Getenv("APITOOLKIT_KEY"),
+		RootURL:            "http://localhost:8080",
+		RedactHeaders:      []string{"X-Api-Key", "Accept-Encoding"},
+		RedactResponseBody: exampleDataRedaction,
+		Tags:               []string{"staging"},
+	}
 	client, err := NewClient(ctx, cfg)
 	defer client.Close()
 	assert.NoError(t, err)

--- a/native.go
+++ b/native.go
@@ -3,7 +3,7 @@ package apitoolkit
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -23,9 +23,9 @@ func (c *Client) Middleware(next http.Handler) http.Handler {
 		newCtx = context.WithValue(newCtx, ErrorListCtxKey, &errorList)
 		req = req.WithContext(newCtx)
 
-		reqBuf, _ := ioutil.ReadAll(req.Body)
+		reqBuf, _ := io.ReadAll(req.Body)
 		req.Body.Close()
-		req.Body = ioutil.NopCloser(bytes.NewBuffer(reqBuf))
+		req.Body = io.NopCloser(bytes.NewBuffer(reqBuf))
 
 		rec := httptest.NewRecorder()
 		start := time.Now()
@@ -38,7 +38,7 @@ func (c *Client) Middleware(next http.Handler) http.Handler {
 				res.Header().Add(k, vv)
 			}
 		}
-		resBody, _ := ioutil.ReadAll(recRes.Body)
+		resBody, _ := io.ReadAll(recRes.Body)
 		res.WriteHeader(recRes.StatusCode)
 		res.Write(resBody)
 
@@ -65,9 +65,9 @@ func (c *Client) GorillaMuxMiddleware(next http.Handler) http.Handler {
 		newCtx = context.WithValue(req.Context(), ErrorListCtxKey, &errorList)
 		req = req.WithContext(newCtx)
 
-		reqBuf, _ := ioutil.ReadAll(req.Body)
+		reqBuf, _ := io.ReadAll(req.Body)
 		req.Body.Close()
-		req.Body = ioutil.NopCloser(bytes.NewBuffer(reqBuf))
+		req.Body = io.NopCloser(bytes.NewBuffer(reqBuf))
 
 		rec := httptest.NewRecorder()
 		start := time.Now()
@@ -79,7 +79,7 @@ func (c *Client) GorillaMuxMiddleware(next http.Handler) http.Handler {
 				res.Header().Add(k, vv)
 			}
 		}
-		resBody, _ := ioutil.ReadAll(recRes.Body)
+		resBody, _ := io.ReadAll(recRes.Body)
 		res.WriteHeader(recRes.StatusCode)
 		res.Write(resBody)
 

--- a/native_test.go
+++ b/native_test.go
@@ -85,15 +85,13 @@ func TestNativeGoMiddleware(t *testing.T) {
 	)
 	assert.NoError(t, err)
 	assert.True(t, publishCalled)
-
 }
-
 
 func TestGorillaGoMiddleware(t *testing.T) {
 	client := &Client{
 		config: &Config{
-			Debug: true,
-			VerboseDebug: true,
+			Debug:              true,
+			VerboseDebug:       true,
 			RedactHeaders:      []string{"X-Api-Key", "Accept-Encoding"},
 			RedactResponseBody: exampleDataRedaction,
 		},
@@ -102,7 +100,7 @@ func TestGorillaGoMiddleware(t *testing.T) {
 	client.PublishMessage = func(ctx context.Context, payload Payload) error {
 		assert.Equal(t, "POST", payload.Method)
 		assert.Equal(t, "/{param1:[a-z]+}/test", payload.URLPath)
-		assert.Equal(t, map[string]string{"param1":"paramval"}, payload.PathParams)
+		assert.Equal(t, map[string]string{"param1": "paramval"}, payload.PathParams)
 		assert.Equal(t, map[string][]string{
 			"param1": {"abc"},
 			"param2": {"123"},
@@ -148,7 +146,6 @@ func TestGorillaGoMiddleware(t *testing.T) {
 		w.Write(jsonByte)
 	}
 
-
 	r := mux.NewRouter()
 	r.Use(client.GorillaMuxMiddleware)
 	r.HandleFunc("/{param1:[a-z]+}/test", handlerFn).Methods(http.MethodPost)
@@ -167,5 +164,4 @@ func TestGorillaGoMiddleware(t *testing.T) {
 	)
 	assert.NoError(t, err)
 	assert.True(t, publishCalled)
-
 }

--- a/native_test.go
+++ b/native_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -59,7 +59,7 @@ func TestNativeGoMiddleware(t *testing.T) {
 	}
 
 	handlerFn := func(w http.ResponseWriter, r *http.Request) {
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, body)
 
@@ -133,7 +133,7 @@ func TestGorillaGoMiddleware(t *testing.T) {
 	}
 
 	handlerFn := func(w http.ResponseWriter, r *http.Request) {
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, body)
 

--- a/outgoing.go
+++ b/outgoing.go
@@ -3,7 +3,7 @@ package apitoolkit
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"time"
@@ -31,8 +31,8 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (res *http.Response, err er
 	// Capture the request body
 	reqBodyBytes := []byte{}
 	if req.Body != nil {
-		reqBodyBytes, _ = ioutil.ReadAll(req.Body)
-		req.Body = ioutil.NopCloser(bytes.NewBuffer(reqBodyBytes))
+		reqBodyBytes, _ = io.ReadAll(req.Body)
+		req.Body = io.NopCloser(bytes.NewBuffer(reqBodyBytes))
 	}
 
 	// Add a header to all outgoing requests "X-APITOOLKIT-TRACE-PARENT-ID"
@@ -53,8 +53,8 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (res *http.Response, err er
 
 	// Capture the response body
 	if res != nil {
-		respBodyBytes, _ := ioutil.ReadAll(res.Body)
-		res.Body = ioutil.NopCloser(bytes.NewBuffer(respBodyBytes))
+		respBodyBytes, _ := io.ReadAll(res.Body)
+		res.Body = io.NopCloser(bytes.NewBuffer(respBodyBytes))
 		payload = rt.client.buildPayload(
 			GoOutgoing,
 			start, req, res.StatusCode, reqBodyBytes,

--- a/sdk.go
+++ b/sdk.go
@@ -2,7 +2,7 @@
 // It monitors incoming traffic, gathers the requests and sends the request to the apitoolkit servers.
 //
 // APIToolkit go sdk can be used with most popular Golang routers off the box. And if your routing library of choice is not supported,
-// feel free to leave an issue on github, or send in a pul request.
+// feel free to leave an issue on github, or send in a pull request.
 //
 // Here's how the SDK can be used with a gin server:
 //
@@ -69,7 +69,7 @@ type Payload struct {
 	ProtoMajor      int                 `json:"proto_major"`
 	Duration        time.Duration       `json:"duration"`
 	Errors          []ATError           `json:"errors"`
-	ServiceVersion  *string              `json:"service_version"`
+	ServiceVersion  *string             `json:"service_version"`
 	Tags            []string            `json:"tags"`
 	MsgID           string              `json:"msg_id"`
 	ParentID        *string             `json:"parent_id"`
@@ -220,8 +220,8 @@ func (c *Client) buildPayload(SDKType string, trackingStart time.Time, req *http
 		parentIDVal = &parentIDStr
 	}
 
-	var serviceVersion *string 
-	if c.config.ServiceVersion != ""{
+	var serviceVersion *string
+	if c.config.ServiceVersion != "" {
 		serviceVersion = &c.config.ServiceVersion
 	}
 	return Payload{

--- a/sdk.go
+++ b/sdk.go
@@ -272,7 +272,7 @@ func redact(data []byte, redactList []string) []byte {
 }
 
 func redactHeaders(headers map[string][]string, redactList []string) map[string][]string {
-	for k, _ := range headers {
+	for k := range headers {
 		if find(redactList, k) {
 			headers[k] = []string{"[CLIENT_REDACTED]"}
 		}

--- a/sdk_test.go
+++ b/sdk_test.go
@@ -3,7 +3,7 @@ package apitoolkit
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -87,7 +87,7 @@ func TestOutgoingMiddleware(t *testing.T) {
 	}
 
 	handlerFn := func(w http.ResponseWriter, r *http.Request) {
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, body)
 

--- a/sdk_test.go
+++ b/sdk_test.go
@@ -117,8 +117,8 @@ func TestOutgoingMiddleware(t *testing.T) {
 		}, payload.QueryParams)
 
 		assert.Equal(t, map[string][]string{
-			"Content-Type":    {"application/json"},
-			"X-Api-Key":       {"past-3"},
+			"Content-Type": {"application/json"},
+			"X-Api-Key":    {"past-3"},
 		}, payload.RequestHeaders)
 		assert.Equal(t, "/test?param1=abc&param2=123", payload.RawURL)
 		assert.Equal(t, http.StatusAccepted, payload.StatusCode)
@@ -130,7 +130,6 @@ func TestOutgoingMiddleware(t *testing.T) {
 
 		assert.Equal(t, reqData, payload.RequestBody)
 		// assert.Equal(t, respData, payload.ResponseBody)
-
 
 		return nil
 	}
@@ -151,7 +150,6 @@ func TestOutgoingMiddleware(t *testing.T) {
 	)
 	assert.NoError(t, err)
 	assert.True(t, publishCalled)
-
 }
 
 var exampleData = map[string]interface{}{


### PR DESCRIPTION
This PR makes subtle code changes including:

- Replacing deprecated functions from the `io/ioutil` package, with functions from `io` package. The former functions just call functions in `io` now.
- Simplifying a `range` expression
- Code formatting